### PR TITLE
Add multilingual pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,21 +1,21 @@
 @font-face {
-    font-family: 'LINERg';
+    font-family: 'LINE SEED Sans';
     font-weight: 45 920;
     font-style: normal;
     font-display: swap;
-    src: url('fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
+    src: url('../fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
 }
 @font-face {
-    font-family: 'LINEBd';
+    font-family: 'LINE SEED Sans';
     font-weight: 45 920;
     font-style: bold;
     font-display: swap;
-    src: url('fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
+    src: url('../fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
 }
 
 /* 전체설정 */
 * {
-    font-family: 'LINERg', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     color: #e9e9e9;
     font-size: 14pt;
     background-color: #151515;
@@ -125,7 +125,7 @@ main {
 
 .main-title .title a,
 .main-title .title2 a {
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     color: #e9e9e9;
     text-decoration-line: none;
     opacity: 0.05;
@@ -142,7 +142,7 @@ main img {
 }
 
 main h1 {
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     font-size: 2.5rem;
 }
 
@@ -161,7 +161,7 @@ main h1 {
 
 .main-text .boost2:hover {
     color: #80CA4E;
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     transition: color 0.1s ease-in-out;
 }
 
@@ -211,6 +211,17 @@ main h1 {
 }
 
 /* contact 파트 */
+.language-toggle {
+    text-align: center;
+    margin-top: 10px;
+}
+.language-toggle a {
+    color: #e9e9e9;
+    margin: 0 5px;
+}
+.language-toggle a:hover {
+    color: #80CA4E;
+}
 .contact {
     display: flex;
     justify-content: center;

--- a/css/style.css
+++ b/css/style.css
@@ -1,14 +1,14 @@
 @font-face {
     font-family: 'LINE SEED Sans';
-    font-weight: 45 920;
+    font-weight: 400;
     font-style: normal;
     font-display: swap;
     src: url('../fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
 }
 @font-face {
     font-family: 'LINE SEED Sans';
-    font-weight: 45 920;
-    font-style: bold;
+    font-weight: 700;
+    font-style: normal;
     font-display: swap;
     src: url('../fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
 }

--- a/css/style_about-me.css
+++ b/css/style_about-me.css
@@ -1,22 +1,22 @@
 @import url(style.css);
 
 @font-face {
-    font-family: 'LINERg';
+    font-family: 'LINE SEED Sans';
     font-weight: 45 920;
     font-style: normal;
     font-display: swap;
-    src: url('fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
+    src: url('../fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
 }
 @font-face {
-    font-family: 'LINEBd';
+    font-family: 'LINE SEED Sans';
     font-weight: 45 920;
     font-style: bold;
     font-display: swap;
-    src: url('fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
+    src: url('../fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
 }
 /* 전체설정 */
 * {
-    font-family: 'LINERg', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     color: #e9e9e9;
     font-size: 14pt;
     background-color: #151515;
@@ -109,13 +109,13 @@ main img {
     margin: 0 auto;
 }
 main h1 {
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     font-size: 2rem;
 }
 
 .boost:hover {
     color: rgb(255, 53, 53);
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     transition: color 0.3s ease-in;
 }
 

--- a/css/style_about-me.css
+++ b/css/style_about-me.css
@@ -2,15 +2,15 @@
 
 @font-face {
     font-family: 'LINE SEED Sans';
-    font-weight: 45 920;
+    font-weight: 400;
     font-style: normal;
     font-display: swap;
     src: url('../fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
 }
 @font-face {
     font-family: 'LINE SEED Sans';
-    font-weight: 45 920;
-    font-style: bold;
+    font-weight: 700;
+    font-style: normal;
     font-display: swap;
     src: url('../fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
 }

--- a/css/style_contact.css
+++ b/css/style_contact.css
@@ -2,23 +2,23 @@
 
 /* 폰트 설정 */
 @font-face {
-    font-family: 'LINERg';
+    font-family: 'LINE SEED Sans';
     font-weight: 45 920;
     font-style: normal;
     font-display: swap;
-    src: url('fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
+    src: url('../fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
 }
 @font-face {
-    font-family: 'LINEBd';
+    font-family: 'LINE SEED Sans';
     font-weight: 45 920;
     font-style: bold;
     font-display: swap;
-    src: url('fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
+    src: url('../fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
 }
 
 /* 전체설정 */
 * {
-    font-family: 'LINERg', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     color: #e9e9e9;
     font-size: 14pt;
     background-color: #151515;
@@ -121,14 +121,14 @@ main img {
 }
 
 main h1 {
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     font-size: 2.5rem;
 }
 
 /* 강조 텍스트 설정 */
 .boost:hover {
     color: rgb(255, 53, 53);
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     transition: color 0.3s ease-in;
 }
 
@@ -158,7 +158,7 @@ main h1 {
 }
 
 #contact-section h1 {
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     font-size: 2.5rem;
     align-items: center;
     justify-content: center;

--- a/css/style_contact.css
+++ b/css/style_contact.css
@@ -3,15 +3,15 @@
 /* 폰트 설정 */
 @font-face {
     font-family: 'LINE SEED Sans';
-    font-weight: 45 920;
+    font-weight: 400;
     font-style: normal;
     font-display: swap;
     src: url('../fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
 }
 @font-face {
     font-family: 'LINE SEED Sans';
-    font-weight: 45 920;
-    font-style: bold;
+    font-weight: 700;
+    font-style: normal;
     font-display: swap;
     src: url('../fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
 }

--- a/css/style_skills.css
+++ b/css/style_skills.css
@@ -2,7 +2,7 @@
 
 @font-face {
     font-family: 'LINE SEED Sans';
-    font-weight: 45 920;
+    font-weight: 400;
     font-style: normal;
     font-display: swap;
     src: url('../fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
@@ -10,8 +10,8 @@
 
 @font-face {
     font-family: 'LINE SEED Sans';
-    font-weight: 45 920;
-    font-style: bold;
+    font-weight: 700;
+    font-style: normal;
     font-display: swap;
     src: url('../fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
 }

--- a/css/style_skills.css
+++ b/css/style_skills.css
@@ -1,24 +1,24 @@
 @import url(style.css);
 
 @font-face {
-    font-family: 'LINERg';
+    font-family: 'LINE SEED Sans';
     font-weight: 45 920;
     font-style: normal;
     font-display: swap;
-    src: url('fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
+    src: url('../fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
 }
 
 @font-face {
-    font-family: 'LINEBd';
+    font-family: 'LINE SEED Sans';
     font-weight: 45 920;
     font-style: bold;
     font-display: swap;
-    src: url('fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
+    src: url('../fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
 }
 
 /* 전체설정 */
 * {
-    font-family: 'LINERg', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     color: #e9e9e9;
     font-size: 14pt;
     background-color: #151515;
@@ -108,7 +108,7 @@ main img {
 }
 
 main h1 {
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     font-size: 3rem;
 }
 
@@ -116,7 +116,7 @@ main h1 {
 
 .boost:hover {
     color: rgb(255, 53, 53);
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     transition: color 0.3s ease-in;
 }
 
@@ -146,7 +146,7 @@ main h1 {
 }
 
 .skills h5 {
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     font-size: 1.25rem;
     margin-top: -30px;
 }
@@ -221,13 +221,13 @@ main h1 {
 
 .modal-content h2 {
     font-size: 1.5rem;
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     background-color: transparent;
 }
 
 .modal-content p {
     font-size: 1rem;
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     background-color: transparent;
 }
 

--- a/css/style_works.css
+++ b/css/style_works.css
@@ -3,22 +3,22 @@
 /* 폰트 설정 */
 @font-face {
     font-family: 'LINE SEED Sans';
-    font-weight: 45 920;
+    font-weight: 400;
     font-style: normal;
     font-display: swap;
     src: url('../fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
 }
 @font-face {
     font-family: 'LINE SEED Sans';
-    font-weight: 45 920;
-    font-style: bold;
+    font-weight: 700;
+    font-style: normal;
     font-display: swap;
     src: url('../fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
 }
 @font-face {
     font-family: 'LINE SEED Sans';
-    font-weight: 45 920;
-    font-style: italic;
+    font-weight: 300;
+    font-style: normal;
     font-display: swap;
     src: url('../fonts/woff2/LINESeedKR-Th.woff2') format('woff2-variations');
 }

--- a/css/style_works.css
+++ b/css/style_works.css
@@ -2,30 +2,30 @@
 
 /* 폰트 설정 */
 @font-face {
-    font-family: 'LINERg';
+    font-family: 'LINE SEED Sans';
     font-weight: 45 920;
     font-style: normal;
     font-display: swap;
-    src: url('fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
+    src: url('../fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
 }
 @font-face {
-    font-family: 'LINEBd';
+    font-family: 'LINE SEED Sans';
     font-weight: 45 920;
     font-style: bold;
     font-display: swap;
-    src: url('fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
+    src: url('../fonts/woff2/LINESeedKR-Bd.woff2') format('woff2-variations');
 }
 @font-face {
-    font-family: 'LINEth';
+    font-family: 'LINE SEED Sans';
     font-weight: 45 920;
     font-style: italic;
     font-display: swap;
-    src: url('fonts/woff2/LINESeedKR-Th.woff2') format('woff2-variations');
+    src: url('../fonts/woff2/LINESeedKR-Th.woff2') format('woff2-variations');
 }
 
 /* 전체설정 */
 * {
-    font-family: 'LINERg', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     color: #e9e9e9;
     font-size: 14pt;
     background-color: #151515;
@@ -126,14 +126,14 @@ main img {
 }
 
 main h1 {
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     font-size: 2.5rem;
 }
 
 /* 포트폴리오 관련 */
 .portfolio p .boost:hover {
     color: #80CA4E;
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     transition: color 0.3s ease-in;
 }
 
@@ -143,13 +143,13 @@ main h1 {
 }
 
 .portfolio h1 {
-    font-family: 'LINEBd', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     font-size: 3rem;
     margin: 10px;
 }
 
 .portfolio p, p .boost {
-    font-family: 'LINEth', sans-serif;
+    font-family: 'LINE SEED Sans', sans-serif;
     font-size: 1rem;
     margin: 0;
 }

--- a/index_en.html
+++ b/index_en.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,14 +8,12 @@
     <link rel="stylesheet" href="./css/style.css">
 </head>
 <body>
-    
-    <!-- 헤더 시작부분 -->
     <header>
         <nav>
         <div class="logo">
-            <a href="./index.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
+            <a href="./index_en.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
         </div>
-        <button type="button" class="hamburger" aria-label="메뉴">
+        <button type="button" class="hamburger" aria-label="Menu">
             <span></span>
             <span></span>
             <span></span>
@@ -36,9 +34,6 @@
         </ul>
         </nav>
     </header>
-    <!-- 헤더 끝부분 -->
-
-    <!-- 메인 시작부분 -->
     <main>
         <section class="about" onclick="toggleMediaPlayback(this)">
             <div class="title">
@@ -48,22 +43,21 @@
         <section class="main">
             <div class="main-text">
                 <h1 class="main-title">Seamless <span id="boost">Creativity.</span></h1>
-                <p><strong>안녕하세요, <br>
-                    <span class="boost">끊기지 않는 창의력</span>을 가진 디자이너, <br>
-                    <span class="boost2"><a href="./about-me.html">유수종입니다.</a></span></strong></p>
+                <p><strong>Hello, <br>
+                    <span class="boost">a designer with seamless creativity,</span><br>
+                    <span class="boost2"><a href="./about-me.html">I'm Yoo Sujong.</a></span></strong></p>
             </div>
             <div class="main-img">
                 <img src="./img/main@4x.webp" alt="main" style="max-width: 100%; height: auto;">
             </div>
         </section>
         <section class="about-me">
-
         </section>
         <section class="contact">
             <div class="contact-text">
                 <p>
                 <h1 class="contact-title">Need Contact?</h1>
-                <h2>연락은 이 쪽으로 부탁드립니다.</h2>
+                <h2>Please reach me through the contact page.</h2>
                 </p>
                 <a href="./contact.html"><button>Contact</button></a>
             </div>
@@ -73,11 +67,11 @@
         <div class="footer-text">
             <p>© 2024 You Sujong. All rights reserved.</p>
         </div>
-    <div class="language-toggle">
-        <a href="index.html">한국어</a> |
-        <a href="index_en.html">English</a> |
-        <a href="index_ja.html">日本語</a>
-    </div>
+        <div class="language-toggle">
+            <a href="index.html">한국어</a> |
+            <a href="index_en.html">English</a> |
+            <a href="index_ja.html">日本語</a>
+        </div>
     </footer>
     <script src="./script.js"></script>
 </body>

--- a/index_ja.html
+++ b/index_ja.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="ja">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,14 +8,12 @@
     <link rel="stylesheet" href="./css/style.css">
 </head>
 <body>
-    
-    <!-- 헤더 시작부분 -->
     <header>
         <nav>
         <div class="logo">
-            <a href="./index.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
+            <a href="./index_ja.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
         </div>
-        <button type="button" class="hamburger" aria-label="메뉴">
+        <button type="button" class="hamburger" aria-label="メニュー">
             <span></span>
             <span></span>
             <span></span>
@@ -36,9 +34,6 @@
         </ul>
         </nav>
     </header>
-    <!-- 헤더 끝부분 -->
-
-    <!-- 메인 시작부분 -->
     <main>
         <section class="about" onclick="toggleMediaPlayback(this)">
             <div class="title">
@@ -48,22 +43,21 @@
         <section class="main">
             <div class="main-text">
                 <h1 class="main-title">Seamless <span id="boost">Creativity.</span></h1>
-                <p><strong>안녕하세요, <br>
-                    <span class="boost">끊기지 않는 창의력</span>을 가진 디자이너, <br>
-                    <span class="boost2"><a href="./about-me.html">유수종입니다.</a></span></strong></p>
+                <p><strong>こんにちは、<br>
+                    <span class="boost">途切れない創造力</span>を持つデザイナー、<br>
+                    <span class="boost2"><a href="./about-me.html">ユ・スジョンです。</a></span></strong></p>
             </div>
             <div class="main-img">
                 <img src="./img/main@4x.webp" alt="main" style="max-width: 100%; height: auto;">
             </div>
         </section>
         <section class="about-me">
-
         </section>
         <section class="contact">
             <div class="contact-text">
                 <p>
                 <h1 class="contact-title">Need Contact?</h1>
-                <h2>연락은 이 쪽으로 부탁드립니다.</h2>
+                <h2>ご連絡は下記よりお願いいたします。</h2>
                 </p>
                 <a href="./contact.html"><button>Contact</button></a>
             </div>
@@ -73,11 +67,11 @@
         <div class="footer-text">
             <p>© 2024 You Sujong. All rights reserved.</p>
         </div>
-    <div class="language-toggle">
-        <a href="index.html">한국어</a> |
-        <a href="index_en.html">English</a> |
-        <a href="index_ja.html">日本語</a>
-    </div>
+        <div class="language-toggle">
+            <a href="index.html">한국어</a> |
+            <a href="index_en.html">English</a> |
+            <a href="index_ja.html">日本語</a>
+        </div>
     </footer>
     <script src="./script.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add English and Japanese copies of the home page
- use `LINE SEED Sans` font across CSS
- add a footer language toggle for switching pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e155fc150832396def9fd3606d12a