### PR TITLE
Add transitions for works and skills pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -468,3 +468,14 @@ main h1 {
         font-size: 10pt;
     }
 }
+
+.fade-on-scroll {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.fade-on-scroll.in-view {
+    opacity: 1;
+    transform: translateY(0);
+}

--- a/css/style_skills.css
+++ b/css/style_skills.css
@@ -8,6 +8,7 @@
     src: url('../fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
 }
 
+
 @font-face {
     font-family: 'LINE SEED Sans';
     font-weight: 700;

--- a/css/style_works.css
+++ b/css/style_works.css
@@ -244,6 +244,12 @@ main h1 {
     transition: opacity 0.25s ease;
 }
 
+.hidden {
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.25s ease-in-out;
+}
+
 .modal-content {
     background-color: #151515;
     margin: 15% auto;

--- a/script.js
+++ b/script.js
@@ -9,13 +9,10 @@ const navMenu = document.querySelector('nav ul');
 let isPaused = false;
 
 // 3. 이벤트 리스너
-// 3.1 스크롤 이벤트
-window.addEventListener('scroll', () => {
+window.addEventListener("scroll", () => {
   requestAnimationFrame(scrollCheck);
-  document.addEventListener('DOMContentLoaded', () => {
-    initHamburgerMenu();
 });
-});
+
 function scrollCheck() {
   const browserScrollY = window.scrollY || window.pageYOffset;
   headerEl.classList.toggle("active", browserScrollY > 0);
@@ -153,5 +150,23 @@ window.onclick = function(event) {
 }
 
 // 페이지 로드 시 초기화
-document.addEventListener('DOMContentLoaded', initHamburgerMenu);
+document.addEventListener('DOMContentLoaded', () => {
+  initHamburgerMenu();
+  initScrollAnimations();
+});
+
+function initScrollAnimations() {
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('in-view');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+
+  document.querySelectorAll('.fade-on-scroll').forEach(el => {
+    observer.observe(el);
+  });
+}
 

--- a/skills.html
+++ b/skills.html
@@ -44,43 +44,43 @@
         <div class="skills">
             <h1>My Skills</h1><h5>in nutshell</h5>
             <div class="skills-list">
-        <button class="skills-list-detail" onclick="openModal('modal1')">
+        <button class="skills-list-detail fade-on-scroll" onclick="openModal('modal1')">
         <img src="./img/tool_photoshop.png" alt="Tool 1" class="skill-icon">
         <br><span>Adobe Photoshop</span>
         </button>
-        <button class="skills-list-detail" onclick="openModal('modal2')">
+        <button class="skills-list-detail fade-on-scroll" onclick="openModal('modal2')">
         <img src="./img/tool_illust.png" alt="Tool 2" class="skill-icon">
         <br><span>Adobe Illustrator</span>
         </button>
-        <button class="skills-list-detail" onclick="openModal('modal3')">
+        <button class="skills-list-detail fade-on-scroll" onclick="openModal('modal3')">
         <img src="./img/tool_ae.png" alt="Tool 3" class="skill-icon">
         <br><span>Adobe After Effects</span>
         </button>
-        <button class="skills-list-detail" onclick="openModal('modal4')">
+        <button class="skills-list-detail fade-on-scroll" onclick="openModal('modal4')">
         <img src="./img/tool_premiere.png" alt="Tool 4" class="skill-icon">
         <br><span>Adobe Premiere Pro</span>
         </button>
-        <button class="skills-list-detail" onclick="openModal('modal5')">
+        <button class="skills-list-detail fade-on-scroll" onclick="openModal('modal5')">
         <img src="./img/tool_c4d.png" alt="Tool 5" class="skill-icon">
         <br><span>Maxon Cinema 4D</span>
         </button>
-        <button class="skills-list-detail" onclick="openModal('modal6')">
+        <button class="skills-list-detail fade-on-scroll" onclick="openModal('modal6')">
         <img src="./img/tool_blender.png" alt="Tool 6" class="skill-icon">
         <br><span>Blender</span>
         </button>
-        <button class="skills-list-detail" onclick="openModal('modal7')">
+        <button class="skills-list-detail fade-on-scroll" onclick="openModal('modal7')">
         <img src="./img/tool_figma.png" alt="Tool 7" class="skill-icon">
         <br><span>Figma</span>
         </button>
-        <button class="skills-list-detail" onclick="openModal('modal8')">
+        <button class="skills-list-detail fade-on-scroll" onclick="openModal('modal8')">
         <img src="./img/tool_xd.png" alt="Tool 8" class="skill-icon">
         <br><span>Adobe Xd</span>
         </button>
-        <button class="skills-list-detail" onclick="openModal('modal9')">
+        <button class="skills-list-detail fade-on-scroll" onclick="openModal('modal9')">
         <img src="./img/tool_firefly.png" alt="Tool 9" class="skill-icon">
         <br><span>Adobe Firefly</span>
         </button>
-        <button class="skills-list-detail" onclick="openModal('modal10')">
+        <button class="skills-list-detail fade-on-scroll" onclick="openModal('modal10')">
         <img src="./img/tool_dimension.png" alt="Tool 10" class="skill-icon" >
         <br><span>Adobe Dimension</span>
         </button>
@@ -169,37 +169,6 @@
             <p>© 2024 You Sujong. All rights reserved.</p>
         </div>
     </footer>
-    <script>
-function openModal(modalId) {
-    const modal = document.getElementById(modalId);
-    if (modal) {
-        modal.classList.remove('hidden');
-        modal.style.display = 'block';
-        document.body.style.overflow = 'hidden';
-    }
-}
-
-function closeModal(modalId) {
-    const modal = document.getElementById(modalId);
-    if (modal) {
-        modal.classList.add('hidden');
-        document.body.style.overflow = 'auto';
-    }
-}
-
-// 모달 외부 클릭 이벤트 처리
-document.addEventListener('DOMContentLoaded', function() {
-    const modals = document.querySelectorAll('.modal');
-    
-    modals.forEach(modal => {
-        modal.addEventListener('click', function(event) {
-            if (event.target === modal) {
-                closeModal(modal.id);
-            }
-        });
-    });
-});
-      </script>
     <script src="./script.js"></script>
 </body>
 </html>

--- a/works.html
+++ b/works.html
@@ -52,56 +52,56 @@
             <button onclick="filterPortfolio('branding')" aria-pressed="false">브랜딩 프로젝트</button>
         </div>
         <div class="portfolio-grid">
-            <div class="portfolio-item graphic-design" onclick="openModal('modal1')">
+            <div class="portfolio-item graphic-design fade-on-scroll" onclick="openModal('modal1')">
             <img src="./img/work1-thumb.jpeg" alt="아무말">
             <div class="portfolio-caption">
                 <h3>The Typoster</h3>
                 <p>아무런 말과 닉네임으로 지어낸 레터링 콜렉션.</p>
             </div>
             </div>
-            <div class="portfolio-item motion-graphics" onclick="openModal('modal2')">
+            <div class="portfolio-item motion-graphics fade-on-scroll" onclick="openModal('modal2')">
             <img src="./img/work2-thumb.webp" alt="판타지움">
             <div class="portfolio-caption">
                 <h3>상상해봐! 판타지움</h3>
                 <p>쇼핑몰 판타지움의 홍보영상 콘테스트 출품작. 우수상.</p>
             </div>
             </div>
-            <div class="portfolio-item motion-graphics" onclick="openModal('modal3')">
+            <div class="portfolio-item motion-graphics fade-on-scroll" onclick="openModal('modal3')">
             <img src="./img/work3-thumb.webp" alt="소래">
             <div class="portfolio-caption">
                 <h3>소래의 풍차</h3>
                 <p>Web3 Creator Festival 2023 공모전에 출품한 작품. 우수상.</p>
             </div>
             </div>
-            <div class="portfolio-item branding" onclick="openModal('modal4')">
+            <div class="portfolio-item branding fade-on-scroll" onclick="openModal('modal4')">
             <img src="./img/work4-thumb.png" alt="mgame">
             <div class="portfolio-caption">
                 <h3>브랜딩 프로젝트 - 엠게임</h3>
                 <p>[귀혼], [열혈강호 온라인]을 제작한 게임회사 <br> 엠게임의 BI 프로젝트.</p>
             </div>
             </div>
-            <div class="portfolio-item motion-graphics" onclick="openModal('modal5')">
+            <div class="portfolio-item motion-graphics fade-on-scroll" onclick="openModal('modal5')">
             <img src="./img/work5-thumb.png" alt="신데렐라">
             <div class="portfolio-caption">
                 <h3>신데렐라</h3>
                 <p>동화 신데렐라를 오프닝 타이틀 시퀀스로 만든 영상.</p>
             </div>
             </div>
-            <div class="portfolio-item graphic-design" onclick="openModal('modal6')">
+            <div class="portfolio-item graphic-design fade-on-scroll" onclick="openModal('modal6')">
                 <img src="./img/work6-thumb.png" alt="아무말">
                 <div class="portfolio-caption">
                     <h3>게임 타이틀 한글화 #1</h3>
                     <p>말그대로 게임 타이틀을 한글로 만들어본 콜렉션.</p>
                 </div>
                 </div>
-                <div class="portfolio-item graphic-design" onclick="openModal('modal7')">
+                <div class="portfolio-item graphic-design fade-on-scroll" onclick="openModal('modal7')">
                     <img src="./img/work7-thumb.png" alt="아무말_re">
                     <div class="portfolio-caption">
                         <h3>The Typoster Remake</h3>
                         <p>이전에 제작한 레터링 콜렉션을 리메이크한 것.</p>
                     </div>
                     </div>
-                <div class="portfolio-item graphic-design" onclick="openModal('modal8')">
+                <div class="portfolio-item graphic-design fade-on-scroll" onclick="openModal('modal8')">
                     <img src="./img/work8-thumb.jpg" alt="개인전 카탈로그">
                     <div class="portfolio-caption">
                         <h3>무에서 유기로</h3>
@@ -113,7 +113,7 @@
 
         <!-- 모달팝업 -->
         <!-- 레터링 -->
-        <div id="modal1" class="modal">
+        <div id="modal1" class="modal hidden">
             <div class="modal-content">
             <span class="close" onclick="closeModal('modal1')">&times;</span>
             <h1>The Typoster</h1>
@@ -139,7 +139,7 @@
             </div>
         </div>
         <!-- 판타지움 -->
-        <div id="modal2" class="modal">
+        <div id="modal2" class="modal hidden">
             <div class="modal-content">
             <span class="close" onclick="closeModal('modal2')">&times;</span>
             <h1>상상해봐! 판타지움</h1>
@@ -151,7 +151,7 @@
             </div>
         </div>
         <!-- NFT -->
-        <div id="modal3" class="modal">
+        <div id="modal3" class="modal hidden">
             <div class="modal-content">
             <span class="close" onclick="closeModal('modal3')">&times;</span>
             <h1>소래의 풍차</h1>
@@ -162,7 +162,7 @@
             </div>
         </div>
         <!-- 엠게임 -->
-        <div id="modal4" class="modal">
+        <div id="modal4" class="modal hidden">
             <div class="modal-content">
             <span class="close" onclick="closeModal('modal4')">&times;</span>
             <h1>브랜딩 프로젝트 - 엠게임</h1>
@@ -176,7 +176,7 @@
             </div>
         </div>
         <!-- 신데렐라 -->
-        <div id="modal5" class="modal">
+        <div id="modal5" class="modal hidden">
             <div class="modal-content">
             <span class="close" onclick="closeModal('modal5')">&times;</span>
             <h1>신데렐라</h1>
@@ -187,7 +187,7 @@
             </div>
         </div>
         <!-- 현지화 -->
-        <div id="modal6" class="modal">
+        <div id="modal6" class="modal hidden">
             <div class="modal-content">
             <span class="close" onclick="closeModal('modal6')">&times;</span>
             <h1>게임 타이틀 한글화 #1</h1>
@@ -204,7 +204,7 @@
                 </div>
             </div>
             <!-- 레터링 -->
-            <div id="modal7" class="modal">
+            <div id="modal7" class="modal hidden">
                     <div class="modal-content">
                     <span class="close" onclick="closeModal('modal7')">&times;</span>
                     <h1>The Typoster Remake</h1>
@@ -224,7 +224,7 @@
                     </div>
                 </div>
                 <!-- 개인 카탈로그 -->
-                 <div id="modal8" class="modal">
+                 <div id="modal8" class="modal hidden">
                     <div class="modal-content">
                     <span class="close" onclick="closeModal('modal8')">&times;</span>
                     <h1>무에서 유기로</h1>


### PR DESCRIPTION
## Summary
- animate works/skills items when they scroll into view
- smoothly fade modals on works page
- hook scroll animations into existing script
- move fade-on-scroll rules into shared stylesheet
- clean up duplicate modal scripts

## Testing
- `npm test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685f2158ff2083239eba0312d7e0f055