### PR TITLE
Add wipe transition and 10 sample tips

### DIFF
--- a/about-me.html
+++ b/about-me.html
@@ -31,6 +31,9 @@
                 <a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a>
             </li>
             <li>
+                <a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a>
+            </li>
+            <li>
                 <a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a>
             </li>
         </ul>

--- a/contact.html
+++ b/contact.html
@@ -26,6 +26,9 @@
                 <a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a>
             </li>
             <li>
+                <a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a>
+            </li>
+            <li>
                 <a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a>
             </li>
         </ul>

--- a/css/style.css
+++ b/css/style.css
@@ -468,3 +468,32 @@ main h1 {
         font-size: 10pt;
     }
 }
+
+.fade-on-scroll {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.fade-on-scroll.in-view {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.wipe-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: #151515;
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.6s ease;
+    z-index: 9999;
+    pointer-events: none;
+}
+
+.wipe-overlay.active {
+    transform: scaleX(1);
+}

--- a/css/style_skills.css
+++ b/css/style_skills.css
@@ -8,6 +8,7 @@
     src: url('../fonts/woff2/LINESeedKR-Rg.woff2') format('woff2-variations');
 }
 
+
 @font-face {
     font-family: 'LINE SEED Sans';
     font-weight: 700;
@@ -183,6 +184,7 @@ main h1 {
     width: auto;
     height: 50px;
     display: block;
+    opacity: 1;
 }
 
 .skills-list .skills-list-detail span {
@@ -262,6 +264,58 @@ main h1 {
 
 }
 
+/* 차트 레이아웃 */
+.skill-chart {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 10px 0;
+}
+
+.skill-row {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+}
+
+.skill-row img {
+    width: 50px;
+    height: auto;
+}
+
+.skill-info {
+    flex: 1;
+}
+
+.skill-info span {
+    display: block;
+    text-align: left;
+    margin-bottom: 6px;
+    font-size: 1rem;
+}
+
+.progress {
+    width: 100%;
+    height: 10px;
+    background-color: #2b2b2b;
+    border-radius: 5px;
+    overflow: hidden;
+}
+
+.progress-bar {
+    display: block;
+    height: 100%;
+    width: 0;
+    background-color: #80CA4E;
+    transition: width 0.6s ease;
+}
+
+.skill-row.in-view .progress-bar {
+    width: var(--level);
+}
+
 @media screen and (max-width: 768px) {
     nav {
         margin: 0;
@@ -303,6 +357,14 @@ main h1 {
         padding: 8px 16px;
         width: auto;
     }
+
+    .skill-row img {
+        width: 35px;
+    }
+
+    .skill-info span {
+        font-size: 0.9rem;
+    }
 }
 
 /* 더 작은 화면에서의 추가 조정 */
@@ -314,6 +376,14 @@ main h1 {
     
     nav ul {
         gap: 3px;
+    }
+
+    .skill-row img {
+        width: 30px;
+    }
+
+    .skill-info span {
+        font-size: 0.8rem;
     }
 }
 
@@ -382,11 +452,12 @@ main h1 {
 }
 
 @media screen and (max-width: 375px) {
-    .skills-list {
-        grid-template-columns: repeat(2, 1fr);
-        gap: 8px;
-        padding: 5px;
-        margin: 0 auto;
+    .skill-row img {
+        width: 28px;
+    }
+
+    .skill-info span {
+        font-size: 0.75rem;
     }
 
     .skills h1 {

--- a/css/style_tips.css
+++ b/css/style_tips.css
@@ -1,0 +1,56 @@
+@import url(style.css);
+
+.tips-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.tips-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 15px;
+}
+
+.tip-item {
+    position: relative;
+    display: block;
+    background: #1a1a1a;
+    border-radius: 15px;
+    overflow: hidden;
+    aspect-ratio: 1 / 1;
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+}
+
+.tip-thumb {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: #333;
+}
+
+.tip-content {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    padding: 15px;
+    box-sizing: border-box;
+    background: linear-gradient(transparent, rgba(0,0,0,0.6));
+}
+
+.tip-item h3 {
+    margin: 0 0 8px;
+    font-size: 1.1rem;
+}
+
+.tip-item p {
+    font-size: 0.9rem;
+    line-height: 1.4;
+}
+
+

--- a/css/style_works.css
+++ b/css/style_works.css
@@ -244,6 +244,12 @@ main h1 {
     transition: opacity 0.25s ease;
 }
 
+.hidden {
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.25s ease-in-out;
+}
+
 .modal-content {
     background-color: #151515;
     margin: 15% auto;
@@ -287,12 +293,12 @@ main h1 {
     position: relative;
     overflow: hidden;
     border: none;
-    border-radius: 25px;
-    font-size: 12pt;
-    padding: 10px 20px;
-    margin: 5px;
+    border-radius: 30px;
+    font-size: 14pt;
+    padding: 12px 24px;
+    margin: 8px;
     cursor: pointer;
-    transition: background-color 0.2s ease-in, color 0.2s ease-in;
+    transition: background-color 0.2s ease-in, color 0.2s ease-in, transform 0.2s ease-in;
     background-color: #2b2b2b;
     color: #e9e9e9;
 }
@@ -300,16 +306,19 @@ main h1 {
 .portfolio-categories button:hover {
     background-color: #e9e9e9;
     color: #2b2b2b;
+    transform: scale(1.05);
 }
 
 .portfolio-categories button:active {
     background-color: #80CA4E;
     color: #151515;
+    transform: scale(0.95);
 }
 
 .portfolio-categories button[aria-pressed="true"] {
     background-color: #80CA4E;
     color: #151515;
+    transform: scale(1.05);
 }
 
 .portfolio-categories button[aria-pressed="true"]::after {
@@ -335,12 +344,13 @@ main h1 {
 }
 
 .portfolio-item {
-    transition: transform 0.5s ease, opacity 0.5s ease;
-    }
-    .portfolio-item.hidden {
-    transform: scale(0.5);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+.portfolio-item.fade-hidden {
+    transform: scale(0.95);
     opacity: 0;
-    }
+    pointer-events: none;
+}
     
 
     .portfolio-categories {

--- a/index.html
+++ b/index.html
@@ -31,6 +31,9 @@
                 <a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a>
             </li>
             <li>
+                <a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a>
+            </li>
+            <li>
                 <a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a>
             </li>
         </ul>

--- a/index_en.html
+++ b/index_en.html
@@ -29,6 +29,9 @@
                 <a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a>
             </li>
             <li>
+                <a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a>
+            </li>
+            <li>
                 <a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a>
             </li>
         </ul>

--- a/index_ja.html
+++ b/index_ja.html
@@ -29,6 +29,9 @@
                 <a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a>
             </li>
             <li>
+                <a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a>
+            </li>
+            <li>
                 <a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a>
             </li>
         </ul>

--- a/script.js
+++ b/script.js
@@ -9,13 +9,10 @@ const navMenu = document.querySelector('nav ul');
 let isPaused = false;
 
 // 3. 이벤트 리스너
-// 3.1 스크롤 이벤트
-window.addEventListener('scroll', () => {
+window.addEventListener("scroll", () => {
   requestAnimationFrame(scrollCheck);
-  document.addEventListener('DOMContentLoaded', () => {
-    initHamburgerMenu();
 });
-});
+
 function scrollCheck() {
   const browserScrollY = window.scrollY || window.pageYOffset;
   headerEl.classList.toggle("active", browserScrollY > 0);
@@ -23,6 +20,7 @@ function scrollCheck() {
 
 // 3.2 리사이즈 이벤트
 window.addEventListener('resize', () => {
+  if (!navButtonEl) return;
   const windowWidth = window.innerWidth;
   const fontSize = windowWidth / 20;
   const buttonSize = windowWidth / 10;
@@ -33,18 +31,22 @@ window.addEventListener('resize', () => {
 });
 
 // 3.3 이미지 관련 이벤트
-mainImg.addEventListener('click', () => {
-  isPaused = !isPaused;
-  mainImg.classList.toggle("paused", isPaused);
-});
+if (mainImg) {
+  mainImg.addEventListener('click', () => {
+    isPaused = !isPaused;
+    mainImg.classList.toggle("paused", isPaused);
+  });
+}
 
 // 4. 애니메이션 효과
 // 4.1 이미지 페이드 효과
-setInterval(() => {
-  if (!isPaused) {
-    mainImg.classList.toggle("fade");
-  }
-}, 100);
+if (mainImg) {
+  setInterval(() => {
+    if (!isPaused) {
+      mainImg.classList.toggle("fade");
+    }
+  }, 100);
+}
 
 // 4.2 페이드 효과 유틸리티 함수
 function fadeElement(element, start, end, speed, callback) {
@@ -90,41 +92,34 @@ function closeModal(modalId) {
 
 // 6. 포트폴리오 필터링 및 애니메이션
 function filterPortfolio(category) {
-  const items = document.getElementsByClassName('portfolio-item');
   const grid = document.querySelector('.portfolio-grid');
+  const items = document.getElementsByClassName('portfolio-item');
+  if (!grid || items.length === 0) return;
   grid.classList.add('animate-grid');
   
   Array.from(items).forEach((item, index) => {
-    setTimeout(() => {
-      const shouldShow = category === 'all' || item.classList.contains(category);
-      item.style.display = shouldShow ? 'block' : 'none';
-      
-      if (shouldShow) {
-        animateItem(item, index);
-      } else {
-        fadeOutItem(item);
-      }
-    }, 50);
+    const shouldShow = category === 'all' || item.classList.contains(category);
+    if (shouldShow) {
+      showItem(item, index);
+    } else {
+      hideItem(item);
+    }
   });
   
   updateAccessibility(category);
 }
 
 // 7. 아이템 애니메이션 함수
-function animateItem(item, index) {
-  item.style.opacity = '0';
-  item.style.transform = 'translateY(20px)';
-  
+function showItem(item, index) {
+  item.style.display = 'block';
+  item.classList.add('fade-hidden');
   setTimeout(() => {
-    item.style.opacity = '1';
-    item.style.transform = 'translateY(0)';
+    item.classList.remove('fade-hidden');
   }, index * 100);
 }
 
-function fadeOutItem(item) {
-  item.style.opacity = '0';
-  item.style.transform = 'translateY(20px)';
-  
+function hideItem(item) {
+  item.classList.add('fade-hidden');
   setTimeout(() => {
     item.style.display = 'none';
   }, 300);
@@ -133,6 +128,7 @@ function fadeOutItem(item) {
 // 8. 접근성 관련
 function updateAccessibility(category) {
   const buttons = document.querySelectorAll('.portfolio-categories button');
+  if (buttons.length === 0) return;
   buttons.forEach(button => {
     const isSelected = button.textContent.toLowerCase().includes(category) || 
                       (category === 'all' && button.textContent === '전체');
@@ -152,6 +148,71 @@ window.onclick = function(event) {
   }
 }
 
+function initHamburgerMenu() {
+  const hamburger = document.querySelector('.hamburger');
+  const navMenu = document.querySelector('nav ul');
+
+  if (!hamburger || !navMenu) return;
+
+  hamburger.addEventListener('click', () => {
+    hamburger.classList.toggle('active');
+    navMenu.classList.toggle('active');
+  });
+}
+
+function toggleMediaPlayback(section) {
+  const media = section.querySelector('video, audio');
+  if (media) {
+    if (media.paused) {
+      media.play();
+    } else {
+      media.pause();
+    }
+  }
+}
+
 // 페이지 로드 시 초기화
-document.addEventListener('DOMContentLoaded', initHamburgerMenu);
+document.addEventListener('DOMContentLoaded', () => {
+  initHamburgerMenu();
+  initScrollAnimations();
+  initWipeLinks();
+});
+
+function initScrollAnimations() {
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('in-view');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+
+  document.querySelectorAll('.fade-on-scroll').forEach(el => {
+    observer.observe(el);
+  });
+}
+
+function initWipeLinks() {
+  const links = document.querySelectorAll('.wipe-link');
+  links.forEach(link => {
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      const href = link.href;
+      startWipe(() => {
+        window.location.href = href;
+      });
+    });
+  });
+}
+
+function startWipe(callback) {
+  const overlay = document.querySelector('.wipe-overlay');
+  if (!overlay) {
+    callback();
+    return;
+  }
+  overlay.classList.add('active');
+  setTimeout(callback, 600);
+}
 

--- a/skills.html
+++ b/skills.html
@@ -31,6 +31,9 @@
                 <a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a>
             </li>
             <li>
+                <a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a>
+            </li>
+            <li>
                 <a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a>
             </li>
         </ul>
@@ -43,48 +46,78 @@
     <section class="skill">
         <div class="skills">
             <h1>My Skills</h1><h5>in nutshell</h5>
-            <div class="skills-list">
-        <button class="skills-list-detail" onclick="openModal('modal1')">
-        <img src="./img/tool_photoshop.png" alt="Tool 1" class="skill-icon">
-        <br><span>Adobe Photoshop</span>
-        </button>
-        <button class="skills-list-detail" onclick="openModal('modal2')">
-        <img src="./img/tool_illust.png" alt="Tool 2" class="skill-icon">
-        <br><span>Adobe Illustrator</span>
-        </button>
-        <button class="skills-list-detail" onclick="openModal('modal3')">
-        <img src="./img/tool_ae.png" alt="Tool 3" class="skill-icon">
-        <br><span>Adobe After Effects</span>
-        </button>
-        <button class="skills-list-detail" onclick="openModal('modal4')">
-        <img src="./img/tool_premiere.png" alt="Tool 4" class="skill-icon">
-        <br><span>Adobe Premiere Pro</span>
-        </button>
-        <button class="skills-list-detail" onclick="openModal('modal5')">
-        <img src="./img/tool_c4d.png" alt="Tool 5" class="skill-icon">
-        <br><span>Maxon Cinema 4D</span>
-        </button>
-        <button class="skills-list-detail" onclick="openModal('modal6')">
-        <img src="./img/tool_blender.png" alt="Tool 6" class="skill-icon">
-        <br><span>Blender</span>
-        </button>
-        <button class="skills-list-detail" onclick="openModal('modal7')">
-        <img src="./img/tool_figma.png" alt="Tool 7" class="skill-icon">
-        <br><span>Figma</span>
-        </button>
-        <button class="skills-list-detail" onclick="openModal('modal8')">
-        <img src="./img/tool_xd.png" alt="Tool 8" class="skill-icon">
-        <br><span>Adobe Xd</span>
-        </button>
-        <button class="skills-list-detail" onclick="openModal('modal9')">
-        <img src="./img/tool_firefly.png" alt="Tool 9" class="skill-icon">
-        <br><span>Adobe Firefly</span>
-        </button>
-        <button class="skills-list-detail" onclick="openModal('modal10')">
-        <img src="./img/tool_dimension.png" alt="Tool 10" class="skill-icon" >
-        <br><span>Adobe Dimension</span>
-        </button>
-        </div>
+            <div class="skill-chart">
+                <div class="skill-row fade-on-scroll" onclick="openModal('modal1')" style="--level:95%">
+                    <img src="./img/tool_photoshop.png" alt="Adobe Photoshop" class="skill-icon">
+                    <div class="skill-info">
+                        <span>Adobe Photoshop</span>
+                        <div class="progress"><div class="progress-bar"></div></div>
+                    </div>
+                </div>
+                <div class="skill-row fade-on-scroll" onclick="openModal('modal2')" style="--level:90%">
+                    <img src="./img/tool_illust.png" alt="Adobe Illustrator" class="skill-icon">
+                    <div class="skill-info">
+                        <span>Adobe Illustrator</span>
+                        <div class="progress"><div class="progress-bar"></div></div>
+                    </div>
+                </div>
+                <div class="skill-row fade-on-scroll" onclick="openModal('modal3')" style="--level:85%">
+                    <img src="./img/tool_ae.png" alt="Adobe After Effects" class="skill-icon">
+                    <div class="skill-info">
+                        <span>Adobe After Effects</span>
+                        <div class="progress"><div class="progress-bar"></div></div>
+                    </div>
+                </div>
+                <div class="skill-row fade-on-scroll" onclick="openModal('modal4')" style="--level:80%">
+                    <img src="./img/tool_premiere.png" alt="Adobe Premiere Pro" class="skill-icon">
+                    <div class="skill-info">
+                        <span>Adobe Premiere Pro</span>
+                        <div class="progress"><div class="progress-bar"></div></div>
+                    </div>
+                </div>
+                <div class="skill-row fade-on-scroll" onclick="openModal('modal5')" style="--level:70%">
+                    <img src="./img/tool_c4d.png" alt="Maxon Cinema 4D" class="skill-icon">
+                    <div class="skill-info">
+                        <span>Maxon Cinema 4D</span>
+                        <div class="progress"><div class="progress-bar"></div></div>
+                    </div>
+                </div>
+                <div class="skill-row fade-on-scroll" onclick="openModal('modal6')" style="--level:60%">
+                    <img src="./img/tool_blender.png" alt="Blender" class="skill-icon">
+                    <div class="skill-info">
+                        <span>Blender</span>
+                        <div class="progress"><div class="progress-bar"></div></div>
+                    </div>
+                </div>
+                <div class="skill-row fade-on-scroll" onclick="openModal('modal7')" style="--level:85%">
+                    <img src="./img/tool_figma.png" alt="Figma" class="skill-icon">
+                    <div class="skill-info">
+                        <span>Figma</span>
+                        <div class="progress"><div class="progress-bar"></div></div>
+                    </div>
+                </div>
+                <div class="skill-row fade-on-scroll" onclick="openModal('modal8')" style="--level:75%">
+                    <img src="./img/tool_xd.png" alt="Adobe Xd" class="skill-icon">
+                    <div class="skill-info">
+                        <span>Adobe Xd</span>
+                        <div class="progress"><div class="progress-bar"></div></div>
+                    </div>
+                </div>
+                <div class="skill-row fade-on-scroll" onclick="openModal('modal9')" style="--level:65%">
+                    <img src="./img/tool_firefly.png" alt="Adobe Firefly" class="skill-icon">
+                    <div class="skill-info">
+                        <span>Adobe Firefly</span>
+                        <div class="progress"><div class="progress-bar"></div></div>
+                    </div>
+                </div>
+                <div class="skill-row fade-on-scroll" onclick="openModal('modal10')" style="--level:50%">
+                    <img src="./img/tool_dimension.png" alt="Adobe Dimension" class="skill-icon">
+                    <div class="skill-info">
+                        <span>Adobe Dimension</span>
+                        <div class="progress"><div class="progress-bar"></div></div>
+                    </div>
+                </div>
+            </div>
         </div>
 
         
@@ -169,37 +202,6 @@
             <p>© 2024 You Sujong. All rights reserved.</p>
         </div>
     </footer>
-    <script>
-function openModal(modalId) {
-    const modal = document.getElementById(modalId);
-    if (modal) {
-        modal.classList.remove('hidden');
-        modal.style.display = 'block';
-        document.body.style.overflow = 'hidden';
-    }
-}
-
-function closeModal(modalId) {
-    const modal = document.getElementById(modalId);
-    if (modal) {
-        modal.classList.add('hidden');
-        document.body.style.overflow = 'auto';
-    }
-}
-
-// 모달 외부 클릭 이벤트 처리
-document.addEventListener('DOMContentLoaded', function() {
-    const modals = document.querySelectorAll('.modal');
-    
-    modals.forEach(modal => {
-        modal.addEventListener('click', function(event) {
-            if (event.target === modal) {
-                closeModal(modal.id);
-            }
-        });
-    });
-});
-      </script>
     <script src="./script.js"></script>
 </body>
 </html>

--- a/tip1.html
+++ b/tip1.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tip 1</title>
+    <link rel="icon" href="./img/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="./css/style.css">
+</head>
+<body>
+    <header>
+        <nav>
+        <div class="logo">
+            <a href="./index.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
+        </div>
+        <button type="button" class="hamburger" aria-label="메뉴">
+            <span></span><span></span><span></span>
+        </button>
+        <ul>
+            <li><a href="./about-me.html"><button data-animation-scroll="true" data-target="#main">About Me</button></a></li>
+            <li><a href="./skills.html"><button data-animation-scroll="true" data-target="#main">Skills</button></a></li>
+            <li><a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a></li>
+            <li><a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a></li>
+            <li><a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a></li>
+        </ul>
+        </nav>
+    </header>
+    <main>
+        <section class="post-content">
+            <h1>Tip 1</h1>
+            <p>샘플 포스트 1 입니다.</p>
+        </section>
+    </main>
+    <footer>
+        <div class="footer-text">
+            <p>© 2024 You Sujong. All rights reserved.</p>
+        </div>
+    </footer>
+    <script src="./script.js"></script>
+</body>
+</html>

--- a/tip10.html
+++ b/tip10.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tip 10</title>
+    <link rel="icon" href="./img/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="./css/style.css">
+</head>
+<body>
+    <header>
+        <nav>
+        <div class="logo">
+            <a href="./index.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
+        </div>
+        <button type="button" class="hamburger" aria-label="메뉴">
+            <span></span><span></span><span></span>
+        </button>
+        <ul>
+            <li><a href="./about-me.html"><button data-animation-scroll="true" data-target="#main">About Me</button></a></li>
+            <li><a href="./skills.html"><button data-animation-scroll="true" data-target="#main">Skills</button></a></li>
+            <li><a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a></li>
+            <li><a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a></li>
+            <li><a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a></li>
+        </ul>
+        </nav>
+    </header>
+    <main>
+        <section class="post-content">
+            <h1>Tip 10</h1>
+            <p>샘플 포스트 10 입니다.</p>
+        </section>
+    </main>
+    <footer>
+        <div class="footer-text">
+            <p>© 2024 You Sujong. All rights reserved.</p>
+        </div>
+    </footer>
+    <script src="./script.js"></script>
+</body>
+</html>

--- a/tip2.html
+++ b/tip2.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tip 2</title>
+    <link rel="icon" href="./img/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="./css/style.css">
+</head>
+<body>
+    <header>
+        <nav>
+        <div class="logo">
+            <a href="./index.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
+        </div>
+        <button type="button" class="hamburger" aria-label="메뉴">
+            <span></span><span></span><span></span>
+        </button>
+        <ul>
+            <li><a href="./about-me.html"><button data-animation-scroll="true" data-target="#main">About Me</button></a></li>
+            <li><a href="./skills.html"><button data-animation-scroll="true" data-target="#main">Skills</button></a></li>
+            <li><a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a></li>
+            <li><a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a></li>
+            <li><a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a></li>
+        </ul>
+        </nav>
+    </header>
+    <main>
+        <section class="post-content">
+            <h1>Tip 2</h1>
+            <p>샘플 포스트 2 입니다.</p>
+        </section>
+    </main>
+    <footer>
+        <div class="footer-text">
+            <p>© 2024 You Sujong. All rights reserved.</p>
+        </div>
+    </footer>
+    <script src="./script.js"></script>
+</body>
+</html>

--- a/tip3.html
+++ b/tip3.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tip 3</title>
+    <link rel="icon" href="./img/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="./css/style.css">
+</head>
+<body>
+    <header>
+        <nav>
+        <div class="logo">
+            <a href="./index.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
+        </div>
+        <button type="button" class="hamburger" aria-label="메뉴">
+            <span></span><span></span><span></span>
+        </button>
+        <ul>
+            <li><a href="./about-me.html"><button data-animation-scroll="true" data-target="#main">About Me</button></a></li>
+            <li><a href="./skills.html"><button data-animation-scroll="true" data-target="#main">Skills</button></a></li>
+            <li><a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a></li>
+            <li><a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a></li>
+            <li><a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a></li>
+        </ul>
+        </nav>
+    </header>
+    <main>
+        <section class="post-content">
+            <h1>Tip 3</h1>
+            <p>샘플 포스트 3 입니다.</p>
+        </section>
+    </main>
+    <footer>
+        <div class="footer-text">
+            <p>© 2024 You Sujong. All rights reserved.</p>
+        </div>
+    </footer>
+    <script src="./script.js"></script>
+</body>
+</html>

--- a/tip4.html
+++ b/tip4.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tip 4</title>
+    <link rel="icon" href="./img/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="./css/style.css">
+</head>
+<body>
+    <header>
+        <nav>
+        <div class="logo">
+            <a href="./index.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
+        </div>
+        <button type="button" class="hamburger" aria-label="메뉴">
+            <span></span><span></span><span></span>
+        </button>
+        <ul>
+            <li><a href="./about-me.html"><button data-animation-scroll="true" data-target="#main">About Me</button></a></li>
+            <li><a href="./skills.html"><button data-animation-scroll="true" data-target="#main">Skills</button></a></li>
+            <li><a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a></li>
+            <li><a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a></li>
+            <li><a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a></li>
+        </ul>
+        </nav>
+    </header>
+    <main>
+        <section class="post-content">
+            <h1>Tip 4</h1>
+            <p>샘플 포스트 4 입니다.</p>
+        </section>
+    </main>
+    <footer>
+        <div class="footer-text">
+            <p>© 2024 You Sujong. All rights reserved.</p>
+        </div>
+    </footer>
+    <script src="./script.js"></script>
+</body>
+</html>

--- a/tip5.html
+++ b/tip5.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tip 5</title>
+    <link rel="icon" href="./img/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="./css/style.css">
+</head>
+<body>
+    <header>
+        <nav>
+        <div class="logo">
+            <a href="./index.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
+        </div>
+        <button type="button" class="hamburger" aria-label="메뉴">
+            <span></span><span></span><span></span>
+        </button>
+        <ul>
+            <li><a href="./about-me.html"><button data-animation-scroll="true" data-target="#main">About Me</button></a></li>
+            <li><a href="./skills.html"><button data-animation-scroll="true" data-target="#main">Skills</button></a></li>
+            <li><a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a></li>
+            <li><a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a></li>
+            <li><a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a></li>
+        </ul>
+        </nav>
+    </header>
+    <main>
+        <section class="post-content">
+            <h1>Tip 5</h1>
+            <p>샘플 포스트 5 입니다.</p>
+        </section>
+    </main>
+    <footer>
+        <div class="footer-text">
+            <p>© 2024 You Sujong. All rights reserved.</p>
+        </div>
+    </footer>
+    <script src="./script.js"></script>
+</body>
+</html>

--- a/tip6.html
+++ b/tip6.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tip 6</title>
+    <link rel="icon" href="./img/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="./css/style.css">
+</head>
+<body>
+    <header>
+        <nav>
+        <div class="logo">
+            <a href="./index.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
+        </div>
+        <button type="button" class="hamburger" aria-label="메뉴">
+            <span></span><span></span><span></span>
+        </button>
+        <ul>
+            <li><a href="./about-me.html"><button data-animation-scroll="true" data-target="#main">About Me</button></a></li>
+            <li><a href="./skills.html"><button data-animation-scroll="true" data-target="#main">Skills</button></a></li>
+            <li><a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a></li>
+            <li><a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a></li>
+            <li><a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a></li>
+        </ul>
+        </nav>
+    </header>
+    <main>
+        <section class="post-content">
+            <h1>Tip 6</h1>
+            <p>샘플 포스트 6 입니다.</p>
+        </section>
+    </main>
+    <footer>
+        <div class="footer-text">
+            <p>© 2024 You Sujong. All rights reserved.</p>
+        </div>
+    </footer>
+    <script src="./script.js"></script>
+</body>
+</html>

--- a/tip7.html
+++ b/tip7.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tip 7</title>
+    <link rel="icon" href="./img/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="./css/style.css">
+</head>
+<body>
+    <header>
+        <nav>
+        <div class="logo">
+            <a href="./index.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
+        </div>
+        <button type="button" class="hamburger" aria-label="메뉴">
+            <span></span><span></span><span></span>
+        </button>
+        <ul>
+            <li><a href="./about-me.html"><button data-animation-scroll="true" data-target="#main">About Me</button></a></li>
+            <li><a href="./skills.html"><button data-animation-scroll="true" data-target="#main">Skills</button></a></li>
+            <li><a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a></li>
+            <li><a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a></li>
+            <li><a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a></li>
+        </ul>
+        </nav>
+    </header>
+    <main>
+        <section class="post-content">
+            <h1>Tip 7</h1>
+            <p>샘플 포스트 7 입니다.</p>
+        </section>
+    </main>
+    <footer>
+        <div class="footer-text">
+            <p>© 2024 You Sujong. All rights reserved.</p>
+        </div>
+    </footer>
+    <script src="./script.js"></script>
+</body>
+</html>

--- a/tip8.html
+++ b/tip8.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tip 8</title>
+    <link rel="icon" href="./img/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="./css/style.css">
+</head>
+<body>
+    <header>
+        <nav>
+        <div class="logo">
+            <a href="./index.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
+        </div>
+        <button type="button" class="hamburger" aria-label="메뉴">
+            <span></span><span></span><span></span>
+        </button>
+        <ul>
+            <li><a href="./about-me.html"><button data-animation-scroll="true" data-target="#main">About Me</button></a></li>
+            <li><a href="./skills.html"><button data-animation-scroll="true" data-target="#main">Skills</button></a></li>
+            <li><a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a></li>
+            <li><a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a></li>
+            <li><a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a></li>
+        </ul>
+        </nav>
+    </header>
+    <main>
+        <section class="post-content">
+            <h1>Tip 8</h1>
+            <p>샘플 포스트 8 입니다.</p>
+        </section>
+    </main>
+    <footer>
+        <div class="footer-text">
+            <p>© 2024 You Sujong. All rights reserved.</p>
+        </div>
+    </footer>
+    <script src="./script.js"></script>
+</body>
+</html>

--- a/tip9.html
+++ b/tip9.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tip 9</title>
+    <link rel="icon" href="./img/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="./css/style.css">
+</head>
+<body>
+    <header>
+        <nav>
+        <div class="logo">
+            <a href="./index.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
+        </div>
+        <button type="button" class="hamburger" aria-label="메뉴">
+            <span></span><span></span><span></span>
+        </button>
+        <ul>
+            <li><a href="./about-me.html"><button data-animation-scroll="true" data-target="#main">About Me</button></a></li>
+            <li><a href="./skills.html"><button data-animation-scroll="true" data-target="#main">Skills</button></a></li>
+            <li><a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a></li>
+            <li><a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a></li>
+            <li><a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a></li>
+        </ul>
+        </nav>
+    </header>
+    <main>
+        <section class="post-content">
+            <h1>Tip 9</h1>
+            <p>샘플 포스트 9 입니다.</p>
+        </section>
+    </main>
+    <footer>
+        <div class="footer-text">
+            <p>© 2024 You Sujong. All rights reserved.</p>
+        </div>
+    </footer>
+    <script src="./script.js"></script>
+</body>
+</html>

--- a/tips.html
+++ b/tips.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tips & Blog</title>
+    <link rel="icon" href="./img/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="./css/style_tips.css">
+</head>
+<body>
+    <header>
+        <nav>
+        <div class="logo">
+            <a href="./index.html"><img src="./img/favicon-light.png" alt="logo" style="width: 56px;"></a>
+        </div>
+        <button type="button" class="hamburger" aria-label="메뉴">
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+        <ul>
+            <li><a href="./about-me.html"><button data-animation-scroll="true" data-target="#main">About Me</button></a></li>
+            <li><a href="./skills.html"><button data-animation-scroll="true" data-target="#main">Skills</button></a></li>
+            <li><a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a></li>
+            <li><a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a></li>
+            <li><a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a></li>
+        </ul>
+        </nav>
+    </header>
+    <div class="wipe-overlay"></div>
+    <main>
+        <section class="tips-container">
+            <h1>Tips</h1>
+            <div class="tips-grid">
+                <a href="tip1.html" class="tip-item wipe-link fade-on-scroll">
+                    <div class="tip-thumb"></div>
+                    <div class="tip-content">
+                        <h3>첫 번째 팁</h3>
+                        <p>내용을 여기에 적어주세요. 짧은 소개 문구입니다.</p>
+                    </div>
+                </a>
+                <a href="tip2.html" class="tip-item wipe-link fade-on-scroll">
+                    <div class="tip-thumb"></div>
+                    <div class="tip-content">
+                        <h3>두 번째 팁</h3>
+                        <p>여기에 글을 직접 작성해 넣으면 됩니다.</p>
+                    </div>
+                </a>
+                <a href="tip3.html" class="tip-item wipe-link fade-on-scroll">
+                    <div class="tip-thumb"></div>
+                    <div class="tip-content">
+                        <h3>세 번째 팁</h3>
+                        <p>자세한 설명을 넣어보세요.</p>
+                    </div>
+                </a>
+                <a href="tip4.html" class="tip-item wipe-link fade-on-scroll">
+                    <div class="tip-thumb"></div>
+                    <div class="tip-content">
+                        <h3>네 번째 팁</h3>
+                        <p>필요한 내용을 자유롭게 수정하세요.</p>
+                    </div>
+                </a>
+                <a href="tip5.html" class="tip-item wipe-link fade-on-scroll">
+                    <div class="tip-thumb"></div>
+                    <div class="tip-content">
+                        <h3>다섯 번째 팁</h3>
+                        <p>더 많은 내용을 여기에 적습니다.</p>
+                    </div>
+                </a>
+                <a href="tip6.html" class="tip-item wipe-link fade-on-scroll">
+                    <div class="tip-thumb"></div>
+                    <div class="tip-content">
+                        <h3>여섯 번째 팁</h3>
+                        <p>원하는 글을 작성하세요.</p>
+                    </div>
+                </a>
+                <a href="tip7.html" class="tip-item wipe-link fade-on-scroll">
+                    <div class="tip-thumb"></div>
+                    <div class="tip-content">
+                        <h3>일곱 번째 팁</h3>
+                        <p>내용을 자유롭게 수정합니다.</p>
+                    </div>
+                </a>
+                <a href="tip8.html" class="tip-item wipe-link fade-on-scroll">
+                    <div class="tip-thumb"></div>
+                    <div class="tip-content">
+                        <h3>여덟 번째 팁</h3>
+                        <p>예시 텍스트가 들어갑니다.</p>
+                    </div>
+                </a>
+                <a href="tip9.html" class="tip-item wipe-link fade-on-scroll">
+                    <div class="tip-thumb"></div>
+                    <div class="tip-content">
+                        <h3>아홉 번째 팁</h3>
+                        <p>이곳에 설명을 작성합니다.</p>
+                    </div>
+                </a>
+                <a href="tip10.html" class="tip-item wipe-link fade-on-scroll">
+                    <div class="tip-thumb"></div>
+                    <div class="tip-content">
+                        <h3>열 번째 팁</h3>
+                        <p>마지막 예시 글입니다.</p>
+                    </div>
+                </a>
+                <!-- 글을 추가하려면 위 형식의 tip-item 블록을 복사해 작성하세요. -->
+            </div>
+        </section>
+    </main>
+    <footer>
+        <div class="footer-text">
+            <p>© 2024 You Sujong. All rights reserved.</p>
+        </div>
+    </footer>
+    <script src="./script.js"></script>
+</body>
+</html>

--- a/works.html
+++ b/works.html
@@ -31,6 +31,9 @@
                 <a href="./works.html"><button data-animation-scroll="true" data-target="#main">Works</button></a>
             </li>
             <li>
+                <a href="./tips.html"><button data-animation-scroll="true" data-target="#main">Tips</button></a>
+            </li>
+            <li>
                 <a href="./contact.html"><button data-animation-scroll="true" data-target="#main">Contact</button></a>
             </li>
         </ul>
@@ -52,56 +55,56 @@
             <button onclick="filterPortfolio('branding')" aria-pressed="false">브랜딩 프로젝트</button>
         </div>
         <div class="portfolio-grid">
-            <div class="portfolio-item graphic-design" onclick="openModal('modal1')">
+            <div class="portfolio-item graphic-design fade-on-scroll" onclick="openModal('modal1')">
             <img src="./img/work1-thumb.jpeg" alt="아무말">
             <div class="portfolio-caption">
                 <h3>The Typoster</h3>
                 <p>아무런 말과 닉네임으로 지어낸 레터링 콜렉션.</p>
             </div>
             </div>
-            <div class="portfolio-item motion-graphics" onclick="openModal('modal2')">
+            <div class="portfolio-item motion-graphics fade-on-scroll" onclick="openModal('modal2')">
             <img src="./img/work2-thumb.webp" alt="판타지움">
             <div class="portfolio-caption">
                 <h3>상상해봐! 판타지움</h3>
                 <p>쇼핑몰 판타지움의 홍보영상 콘테스트 출품작. 우수상.</p>
             </div>
             </div>
-            <div class="portfolio-item motion-graphics" onclick="openModal('modal3')">
+            <div class="portfolio-item motion-graphics fade-on-scroll" onclick="openModal('modal3')">
             <img src="./img/work3-thumb.webp" alt="소래">
             <div class="portfolio-caption">
                 <h3>소래의 풍차</h3>
                 <p>Web3 Creator Festival 2023 공모전에 출품한 작품. 우수상.</p>
             </div>
             </div>
-            <div class="portfolio-item branding" onclick="openModal('modal4')">
+            <div class="portfolio-item branding fade-on-scroll" onclick="openModal('modal4')">
             <img src="./img/work4-thumb.png" alt="mgame">
             <div class="portfolio-caption">
                 <h3>브랜딩 프로젝트 - 엠게임</h3>
                 <p>[귀혼], [열혈강호 온라인]을 제작한 게임회사 <br> 엠게임의 BI 프로젝트.</p>
             </div>
             </div>
-            <div class="portfolio-item motion-graphics" onclick="openModal('modal5')">
+            <div class="portfolio-item motion-graphics fade-on-scroll" onclick="openModal('modal5')">
             <img src="./img/work5-thumb.png" alt="신데렐라">
             <div class="portfolio-caption">
                 <h3>신데렐라</h3>
                 <p>동화 신데렐라를 오프닝 타이틀 시퀀스로 만든 영상.</p>
             </div>
             </div>
-            <div class="portfolio-item graphic-design" onclick="openModal('modal6')">
+            <div class="portfolio-item graphic-design fade-on-scroll" onclick="openModal('modal6')">
                 <img src="./img/work6-thumb.png" alt="아무말">
                 <div class="portfolio-caption">
                     <h3>게임 타이틀 한글화 #1</h3>
                     <p>말그대로 게임 타이틀을 한글로 만들어본 콜렉션.</p>
                 </div>
                 </div>
-                <div class="portfolio-item graphic-design" onclick="openModal('modal7')">
+                <div class="portfolio-item graphic-design fade-on-scroll" onclick="openModal('modal7')">
                     <img src="./img/work7-thumb.png" alt="아무말_re">
                     <div class="portfolio-caption">
                         <h3>The Typoster Remake</h3>
                         <p>이전에 제작한 레터링 콜렉션을 리메이크한 것.</p>
                     </div>
                     </div>
-                <div class="portfolio-item graphic-design" onclick="openModal('modal8')">
+                <div class="portfolio-item graphic-design fade-on-scroll" onclick="openModal('modal8')">
                     <img src="./img/work8-thumb.jpg" alt="개인전 카탈로그">
                     <div class="portfolio-caption">
                         <h3>무에서 유기로</h3>
@@ -113,7 +116,7 @@
 
         <!-- 모달팝업 -->
         <!-- 레터링 -->
-        <div id="modal1" class="modal">
+        <div id="modal1" class="modal hidden">
             <div class="modal-content">
             <span class="close" onclick="closeModal('modal1')">&times;</span>
             <h1>The Typoster</h1>
@@ -139,7 +142,7 @@
             </div>
         </div>
         <!-- 판타지움 -->
-        <div id="modal2" class="modal">
+        <div id="modal2" class="modal hidden">
             <div class="modal-content">
             <span class="close" onclick="closeModal('modal2')">&times;</span>
             <h1>상상해봐! 판타지움</h1>
@@ -151,7 +154,7 @@
             </div>
         </div>
         <!-- NFT -->
-        <div id="modal3" class="modal">
+        <div id="modal3" class="modal hidden">
             <div class="modal-content">
             <span class="close" onclick="closeModal('modal3')">&times;</span>
             <h1>소래의 풍차</h1>
@@ -162,7 +165,7 @@
             </div>
         </div>
         <!-- 엠게임 -->
-        <div id="modal4" class="modal">
+        <div id="modal4" class="modal hidden">
             <div class="modal-content">
             <span class="close" onclick="closeModal('modal4')">&times;</span>
             <h1>브랜딩 프로젝트 - 엠게임</h1>
@@ -176,7 +179,7 @@
             </div>
         </div>
         <!-- 신데렐라 -->
-        <div id="modal5" class="modal">
+        <div id="modal5" class="modal hidden">
             <div class="modal-content">
             <span class="close" onclick="closeModal('modal5')">&times;</span>
             <h1>신데렐라</h1>
@@ -187,7 +190,7 @@
             </div>
         </div>
         <!-- 현지화 -->
-        <div id="modal6" class="modal">
+        <div id="modal6" class="modal hidden">
             <div class="modal-content">
             <span class="close" onclick="closeModal('modal6')">&times;</span>
             <h1>게임 타이틀 한글화 #1</h1>
@@ -204,7 +207,7 @@
                 </div>
             </div>
             <!-- 레터링 -->
-            <div id="modal7" class="modal">
+            <div id="modal7" class="modal hidden">
                     <div class="modal-content">
                     <span class="close" onclick="closeModal('modal7')">&times;</span>
                     <h1>The Typoster Remake</h1>
@@ -224,7 +227,7 @@
                     </div>
                 </div>
                 <!-- 개인 카탈로그 -->
-                 <div id="modal8" class="modal">
+                 <div id="modal8" class="modal hidden">
                     <div class="modal-content">
                     <span class="close" onclick="closeModal('modal8')">&times;</span>
                     <h1>무에서 유기로</h1>


### PR DESCRIPTION
## Summary
- implement wipe-overlay for page transitions
- convert Tips entries to 10 square links that trigger wipe effect
- style tip items as block links
- add JavaScript to handle wipe transition
- include 10 example tip pages

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f2158ff2083239eba0312d7e0f055